### PR TITLE
feat: add autocompact command

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -291,10 +291,12 @@ pub(crate) struct Session {
     codex_linux_sandbox_exe: Option<PathBuf>,
     user_shell: shell::Shell,
     show_raw_agent_reasoning: bool,
+    autocompact: Option<u64>,
 }
 
 /// The context needed for a single turn of the conversation.
 #[derive(Debug)]
+#[derive(Clone)]
 pub(crate) struct TurnContext {
     pub(crate) client: ModelClient,
     /// The session's current working directory. All relative paths provided by
@@ -490,6 +492,7 @@ impl Session {
             codex_linux_sandbox_exe: config.codex_linux_sandbox_exe.clone(),
             user_shell: default_shell,
             show_raw_agent_reasoning: config.show_raw_agent_reasoning,
+            autocompact: config.autocompact,
         });
 
         // Dispatch the SessionConfiguredEvent first and then report any errors.
@@ -1592,6 +1595,29 @@ async fn run_task(
                         input_messages: turn_input_messages,
                         last_assistant_message: last_agent_message.clone(),
                     });
+
+                    if let Some(limit) = sess.autocompact {
+                        let usage = {
+                            let st = sess.state.lock_unchecked();
+                            st.token_info.clone()
+                        };
+                        if let Some(info) = usage
+                            && info.total_token_usage.input_tokens > limit
+                        {
+                            const SUMMARIZATION_PROMPT: &str =
+                                include_str!("prompt_for_compact_command.md");
+                            let task = AgentTask::compact(
+                                Arc::clone(&sess),
+                                Arc::new(turn_context.clone()),
+                                sub_id.clone(),
+                                vec![InputItem::Text {
+                                    text: "Start Summarization".to_string(),
+                                }],
+                                SUMMARIZATION_PROMPT.to_string(),
+                            );
+                            sess.set_task(task);
+                        }
+                    }
                     break;
                 }
             }
@@ -1937,6 +1963,7 @@ async fn run_compact_task(
     {
         let mut state = sess.state.lock_unchecked();
         state.history.keep_last_messages(1);
+        state.token_info = None;
     }
 
     let event = Event {
@@ -2914,7 +2941,6 @@ async fn drain_to_completed(
                     })
                     .await
                     .ok();
-
                 return Ok(());
             }
             Ok(_) => continue,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -183,6 +183,9 @@ pub struct Config {
     /// All characters are inserted as they are received, and no buffering
     /// or placeholder replacement will occur for fast keypress bursts.
     pub disable_paste_burst: bool,
+
+    /// Automatically compact the conversation when input tokens exceed this threshold.
+    pub autocompact: Option<u64>,
 }
 
 impl Config {
@@ -342,6 +345,29 @@ pub fn set_project_trusted(codex_home: &Path, project_path: &Path) -> anyhow::Re
     Ok(())
 }
 
+/// Update the `autocompact` threshold in `CODEX_HOME/config.toml`.
+pub fn set_autocompact(codex_home: &Path, threshold: Option<u64>) -> std::io::Result<()> {
+    let config_path = codex_home.join(CONFIG_TOML_FILE);
+    let mut doc = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s
+            .parse::<DocumentMut>()
+            .unwrap_or_else(|_| DocumentMut::new()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => DocumentMut::new(),
+        Err(e) => return Err(e),
+    };
+
+    match threshold {
+        Some(t) => {
+            doc["autocompact"] = toml_edit::value(t as i64);
+        }
+        None => {
+            doc.remove("autocompact");
+        }
+    }
+
+    std::fs::write(config_path, doc.to_string())
+}
+
 /// Apply a single dotted-path override onto a TOML value.
 fn apply_toml_override(root: &mut TomlValue, path: &str, value: TomlValue) {
     use toml::value::Table;
@@ -460,6 +486,8 @@ pub struct ConfigToml {
     pub model_reasoning_summary: Option<ReasoningSummary>,
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
     pub model_verbosity: Option<Verbosity>,
+    /// Automatically compact the conversation when input tokens exceed this threshold.
+    pub autocompact: Option<u64>,
 
     /// Override to force-enable reasoning summaries for the configured model.
     pub model_supports_reasoning_summaries: Option<bool>,
@@ -833,6 +861,7 @@ impl Config {
                 .unwrap_or(false),
             include_view_image_tool,
             disable_paste_burst: cfg.disable_paste_burst.unwrap_or(false),
+            autocompact: cfg.autocompact,
         };
         Ok(config)
     }
@@ -1208,6 +1237,7 @@ model_verbosity = "high"
                 use_experimental_streamable_shell_tool: false,
                 include_view_image_tool: true,
                 disable_paste_burst: false,
+                autocompact: None,
             },
             o3_profile_config
         );
@@ -1265,6 +1295,7 @@ model_verbosity = "high"
             use_experimental_streamable_shell_tool: false,
             include_view_image_tool: true,
             disable_paste_burst: false,
+            autocompact: None,
         };
 
         assert_eq!(expected_gpt3_profile_config, gpt3_profile_config);
@@ -1337,6 +1368,7 @@ model_verbosity = "high"
             use_experimental_streamable_shell_tool: false,
             include_view_image_tool: true,
             disable_paste_burst: false,
+            autocompact: None,
         };
 
         assert_eq!(expected_zdr_profile_config, zdr_profile_config);
@@ -1395,6 +1427,7 @@ model_verbosity = "high"
             use_experimental_streamable_shell_tool: false,
             include_view_image_tool: true,
             disable_paste_burst: false,
+            autocompact: None,
         };
 
         assert_eq!(expected_gpt5_profile_config, gpt5_profile_config);

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -299,6 +299,10 @@ impl App {
             AppEvent::UpdateSandboxPolicy(policy) => {
                 self.chat_widget.set_sandbox_policy(policy);
             }
+            AppEvent::UpdateAutocompact(threshold) => {
+                self.chat_widget.set_autocompact(threshold);
+                self.config.autocompact = threshold;
+            }
         }
         Ok(true)
     }

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -57,6 +57,9 @@ pub(crate) enum AppEvent {
     /// Update the current sandbox policy in the running app and widget.
     UpdateSandboxPolicy(SandboxPolicy),
 
+    /// Update the autocompact threshold in the running app and widget.
+    UpdateAutocompact(Option<u64>),
+
     /// Forwarded conversation history snapshot from the current conversation.
     ConversationHistory(ConversationHistoryResponseEvent),
 }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -240,6 +240,7 @@ fn make_chatwidget_manual() -> (
         frame_requester: FrameRequester::test_dummy(),
         show_welcome_banner: true,
         queued_user_messages: VecDeque::new(),
+        awaiting_autocompact_input: false,
         suppress_session_configured_redraw: false,
     };
     (widget, rx, op_rx)

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -987,6 +987,26 @@ pub(crate) fn new_status_output(
     PlainHistoryCell { lines }
 }
 
+pub(crate) fn new_autocompact_prompt() -> PlainHistoryCell {
+    let lines: Vec<Line<'static>> = vec![
+        "/autocompact".magenta().into(),
+        "Enter token limit (0 to disable)".into(),
+    ];
+    PlainHistoryCell { lines }
+}
+
+pub(crate) fn new_autocompact_set(threshold: Option<u64>) -> PlainHistoryCell {
+    let msg = match threshold {
+        Some(t) => format!("Enabled at {t} tokens"),
+        None => "Disabled".to_string(),
+    };
+    let lines: Vec<Line<'static>> = vec![
+        "/autocompact".magenta().into(),
+        msg.into(),
+    ];
+    PlainHistoryCell { lines }
+}
+
 /// Render a summary of configured MCP servers from the current `Config`.
 pub(crate) fn empty_mcp_output() -> PlainHistoryCell {
     let lines: Vec<Line<'static>> = vec![

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -17,6 +17,7 @@ pub enum SlashCommand {
     New,
     Init,
     Compact,
+    Autocompact,
     Diff,
     Mention,
     Status,
@@ -34,6 +35,7 @@ impl SlashCommand {
             SlashCommand::New => "start a new chat during a conversation",
             SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
             SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
+            SlashCommand::Autocompact => "set auto compact token limit",
             SlashCommand::Quit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
@@ -59,6 +61,7 @@ impl SlashCommand {
             SlashCommand::New
             | SlashCommand::Init
             | SlashCommand::Compact
+            | SlashCommand::Autocompact
             | SlashCommand::Model
             | SlashCommand::Approvals
             | SlashCommand::Logout => false,


### PR DESCRIPTION
## Summary
- add `autocompact` setting and config persistence
- support `/autocompact` command to update token threshold
- trigger automatic compaction when input tokens exceed threshold

## Testing
- `just fix -p codex-core`
- `just fix -p codex-tui`
- `cargo test -p codex-core`
- `cargo test -p codex-tui` *(failed: no output)*
- `cargo test --all-features` *(failed: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68c0752bef7c8324b45e24d6d5c727e1